### PR TITLE
Multiple properties

### DIFF
--- a/src/naga/lang/pabu.clj
+++ b/src/naga/lang/pabu.clj
@@ -67,16 +67,16 @@ Parses code and returns Naga rules."
 
 (def RuleAST
   {:type (s/eq :rule)
-   :head [(s/one VK "property")
-          (s/one Args "arguments")]
+   :head [[(s/one VK "property")
+            (s/one Args "arguments")]]
    :body [Predicate]})
 
 (s/defn ast->rule :- Rule
   "Converts the rule structure returned from the parser"
   [{:keys [head body] :as rule-ast} :- RuleAST]
-  (r/rule (triplet head)
+  (r/rule (map triplet head)
           (mapcat structure body)
-          (-> head first name gensym name)))
+          (-> head ffirst name gensym name)))
 
 (s/defn read-str :- {:rules [Rule]
                      :axioms [Axiom]}

--- a/src/naga/lang/parser.clj
+++ b/src/naga/lang/parser.clj
@@ -47,7 +47,7 @@
 
 ;; a clause with a rule
 (defparser nonbase-clause []
-  (let->> [head (>> opt-whitespace (structure))
+  (let->> [head (>> opt-whitespace (structures))
            _ (>> opt-whitespace (string ":-") opt-whitespace)
            body (structures)
            _ (>> opt-whitespace (char \.) opt-whitespace)]

--- a/src/naga/rules.clj
+++ b/src/naga/rules.clj
@@ -15,7 +15,8 @@
   ([head body name]
    (assert (and (sequential? body) (or (empty? body) (every? sequential? body)))
            "Body must be a sequence of constraints")
-   (assert (sequential? head) "Head must be a constraint")
+   (assert (and (sequential? head) (or (empty? head) (every? sequential? head)))
+           "Head must be a sequence of constraints")
    (st/new-rule head body name)))
 
 (s/defn named-rule :- Rule
@@ -54,7 +55,7 @@
   [& [f :as rs]]
   (let [[nm# rs#] (if (string? f) [f (rest rs)] [(gen-rule-name) rs])
         not-sep# (partial not= :-)
-        head# (de-ns (first (take-while not-sep# rs#)))
+        head# (map de-ns (take-while not-sep# rs#))
         body# (map de-ns (rest (drop-while not-sep# rs#)))]
     `(rule (quote ~head#) (quote ~body#) ~nm#)))
 
@@ -100,7 +101,7 @@
   (let [name-bodies (u/mapmap :name :body rules)
         triggers (fn [head] (mapcat (partial find-matches head) name-bodies))
         deps (fn [{:keys [head body name]}]
-               (st/new-rule head body name (triggers head)))]
+               (st/new-rule head body name (mapcat triggers head)))]
     {:rules (u/mapmap :name identity (map deps rules))
      :axioms axioms}))
 

--- a/src/naga/schema/structs.clj
+++ b/src/naga/schema/structs.clj
@@ -44,6 +44,7 @@
 (def Pattern (s/if list? FilterPattern EPVPattern))
 
 (def Body [Pattern])
+(def Head [EPVPattern])
 
 (def ConstraintData
   {:last-count s/Num  ;; The count from the previous execution
@@ -64,7 +65,7 @@
 ;; the body is conjunction of pattern matches.
 ;; All rules have a name, and a list of names of downstream rules.
 (s/defrecord Rule
-    [head :- EPVPattern
+    [head :- Head
      body :- Body
      name :- s/Str
      salience :- s/Num
@@ -73,16 +74,16 @@
      execution-count :- (s/atom s/Num)])
 
 (s/defn new-rule
-  ([head :- EPVPattern
+  ([head :- Head
     body :- Body
     name :- s/Str]
    (new-rule head body name []))
-  ([head :- EPVPattern
+  ([head :- Head
     body :- Body
     name :- s/Str
     downstream :- [RulePatternPair]]
    (new-rule head body name downstream 0))
-  ([head :- EPVPattern
+  ([head :- Head
     body :- Body
     name :- s/Str
     downstream :- [RulePatternPair]

--- a/src/naga/storage/store_util.clj
+++ b/src/naga/storage/store_util.clj
@@ -16,13 +16,12 @@
    mapping :- {s/Num s/Num}
    row :- [Value]]
   (let [get-node (memoize (fn [n] (store/new-node storage)))
-        node-statements (apply concat
-                               (map (fn [i]
-                                      (let [node (get-node i)]
-                                        [node :db/ident node]))
-                                    nodes))
+        node-statements (mapcat (fn [i]
+                                  (let [node (get-node i)]
+                                    [node :db/ident node]))
+                                nodes)
         update-pattern (fn [p [t f]]
-                         (let [v (if (< f 0) (get-node f) (nth row f))]
+                         (let [v (if (neg? f) (get-node f) (nth row f))]
                            (assoc p t v)))]
     (concat node-statements
             (reduce update-pattern wide-pattern mapping))))

--- a/src/naga/storage/store_util.clj
+++ b/src/naga/storage/store_util.clj
@@ -1,0 +1,23 @@
+(ns ^{:doc "Some common utilities for storage functions"
+      :author "Paula Gearon"}
+    naga.storage.store-util
+  (:require [schema.core :as s]
+            [naga.schema.structs :as st :refer [EPVPattern Value]]
+            [naga.store :as store]))
+
+(s/defn project-row :- [s/Any]
+  "Creates a new EPVPattern from an existing one, based on existing bindings.
+   Uses the mapping to copy from columns in 'row' to overwrite variables in 'pattern'.
+   'pattern' must be a vector.
+   The index mappings have already been found and are in the 'mapping' argument"
+  [storage
+   patterns :- [EPVPattern]
+   mapping :- {s/Num s/Num}
+   row :- [Value]]
+  (let [wide-pattern (vec (apply concat patterns))
+        get-node (memoize (fn [n] (store/new-node storage)))
+        update-pattern (fn [p [t f]]
+                         (let [v (if (< f 0) (get-node f) (nth row f))]
+                           (assoc p t v)))]
+    (partition 3
+               (reduce update-pattern wide-pattern mapping))))

--- a/src/naga/store.clj
+++ b/src/naga/store.clj
@@ -11,9 +11,9 @@
   (container-property [store data] "Returns the property to use to indicate a containership relation for given data. Must be in the naga namespace")
   (resolve-pattern [store pattern] "Resolves a pattern against storage")
   (count-pattern [store pattern] "Counts the size of a pattern resolition against storage")
-  (query [store output-pattern patterns] "Resolves a set of patterns (if not already resolved) and joins the results")
+  (query [store output-patterns patterns] "Resolves a set of patterns (if not already resolved) and joins the results")
   (assert-data [store data] "Inserts new axioms")
-  (query-insert [store assertion-pattern patterns] "Resolves a set of patterns, joins them, and inserts the set of resolutions"))
+  (query-insert [store assertion-patterns patterns] "Resolves a set of patterns, joins them, and inserts the set of resolutions"))
 
 (def registered-stores (atom {}))
 

--- a/test/naga/storage/test_memory.clj
+++ b/test/naga/storage/test_memory.clj
@@ -59,7 +59,7 @@
 
 (defn unordered-query
   [s op pattern]
-  (into #{} (query s op pattern)))
+  (into #{} (query s [op] pattern)))
 
 (deftest test-join
   (let [s (assert-data empty-store jdata)

--- a/test/naga/storage/test_query.clj
+++ b/test/naga/storage/test_query.clj
@@ -91,3 +91,13 @@
              [?a :b ?c]
              (not= ?e ?a)]
            path4))))
+
+(deftest var-mapping
+  (let [m1 (matching-vars `[?a :rel ?c] `[?a ?b ?c] )
+        m2 (matching-vars `[?b :rel ?f] `[?a ?b ?c ?d ?e ?f])
+        m3 (matching-vars `[?b :rel ?f ?b :r2 ?e] `[?a ?b ?c ?d ?e ?f])
+        m4 (matching-vars `[?x :rel ?f ?x :r2 ?e] `[?a ?b ?c ?d ?e ?f])]
+    (is (= m1 {0 0, 2 2}))
+    (is (= m2 {0 1, 2 5}))
+    (is (= m3 {0 1, 2 5, 3 1, 5 4}))
+    (is (= m4 {2 5, 5 4}))))

--- a/test/naga/test_pabu.clj
+++ b/test/naga/test_pabu.clj
@@ -26,7 +26,7 @@ parent(A, F) :- father(A, F).
   [(r [?b :parent ?c] :- [?a :sibling ?b] [?a :parent ?c])
    (r [?a :brother ?b] :- [?a :sibling ?b] [?b :gender :male])
    (r [?a :uncle ?c] :- [?a :parent ?b] [?b :brother ?c])
-   (rule '[?a :sibling ?b]  ['[?a :parent ?p] '[?b :parent ?p] (list not= '?a '?b)])
+   (rule '[[?a :sibling ?b]]  ['[?a :parent ?p] '[?b :parent ?p] (list not= '?a '?b)])
    (r [?f :gender :male] :- [?a :father ?f])
    (r [?a :parent ?f] :- [?a :father ?f])])
 

--- a/test/naga/test_rules.clj
+++ b/test/naga/test_rules.clj
@@ -129,7 +129,20 @@
     (is (= 2 (count
               (filter (fn [[e a v]]
                         (and (= e v) (nodes e) (= :db/ident a)))
-                      data))))))
+                      data)))))
+  (let [rx [(r "multi-prop" [?z :first :a] [?z :second ?y] :- [?x :foo ?y])]
+        ax [[:data :foo :bar] [:other :foo :baz]]
+        program (r/create-program rx ax)
+        [store results] (e/run {:type :memory} program)
+        data' (store/resolve-pattern store '[?e ?a ?v])
+        data (remove #(#{[:data :foo :bar] [:other :foo :baz]} %) data')
+        nodes (set (map first data))]
+    (is (= 6 (count data)))
+    (is (= 2 (count nodes)))
+    (is (= 2 (count (filter (fn [[e a v]] (and (nodes e) (= [:first :a] [a v]))) data))))
+    (is (= 1 (count (filter (fn [[e a v]] (and (nodes e) (= [:second :bar] [a v]))) data))))
+    (is (= 1 (count (filter (fn [[e a v]] (and (nodes e) (= [:second :baz] [a v]))) data))))
+    (is (= 2 (count (filter (fn [[e a v]] (and (nodes e) (= e v) (= :db/ident a))) data))))))
 
 ;; todo blank-multi-prop
 

--- a/test/naga/test_rules.clj
+++ b/test/naga/test_rules.clj
@@ -47,8 +47,8 @@
 
 (deftest single-rule
   (let [ptn '[?a :ancestor ?b]
-        r1 (new-rule '[?a :parent ?b] [ptn] "stub1" [])
-        r2 (new-rule '[?a :parent ?b] [ptn] "stub2" [["stub2" ptn]])
+        r1 (new-rule '[[?a :parent ?b]] [ptn] "stub1" [])
+        r2 (new-rule '[[?a :parent ?b]] [ptn] "stub2" [["stub2" ptn]])
         p1 {:rules {"stub1" r1} :axioms []}
         p2 {:rules {"stub2" r2} :axioms []}]
     (e/execute (:rules p1) stest/empty-store)
@@ -73,10 +73,69 @@
     (is (= 2 (count unk)))
     (is (= #{[:fred :george] [:barney :george]} (set unk)))))
 
+(deftest multi-prop
+  (store/register-storage! :memory mem/create-store)
+  (let [r2 [(r "multi-prop" [?x :first :a] [?x :second :b] :- [?x :foo ?y])]
+        a2 [[:data :foo :bar]]
+        program (r/create-program r2 a2)
+        [store results] (e/run {:type :memory} program)
+        data (store/resolve-pattern store '[?e ?a ?v])]
+    (is (= 3 (count data)))
+    (is (every? #{:data} (map first data)))
+    (is (= #{[:data :foo :bar] [:data :first :a] [:data :second :b]} (set data)))))
+
+(deftest blank-prop
+  (store/register-storage! :memory mem/create-store)
+  (let [rx [(r "multi-prop" [?z :first :a] :- [?x :foo ?y])]
+        ax [[:data :foo :bar]]
+        program (r/create-program rx ax)
+        [store results] (e/run {:type :memory} program)
+        data (store/resolve-pattern store '[?e ?a ?v])
+        data' (remove #(= :data (first %)) data)]
+    (is (= 3 (count data)))
+    (is (= 2 (count data')))
+    (is (not= :data (ffirst data')))
+    (is (apply = (map first data')))))
+
+(deftest blank-multi-prop
+  (store/register-storage! :memory mem/create-store)
+  (let [rx [(r "multi-prop" [?z :first :a] [?z :second ?y] :- [?x :foo ?y])]
+        ax [[:data :foo :bar]]
+        program (r/create-program rx ax)
+        [store results] (e/run {:type :memory} program)
+        data' (store/resolve-pattern store '[?e ?a ?v])
+        data (remove #(= [:data :foo :bar] %) data')
+        node* (map first data)
+        node (first node*)]
+    (is (= 3 (count data)))
+    (is (apply = node*))
+    (is (some #(= [node :first :a] %) data))
+    (is (some #(= [node :second :bar] %) data))
+    (is (some #(= [node :db/ident node] %) data)))
+  (let [rx [(r "multi-prop" [?z :first :a] [?z :second ?y]
+               [?a :first :b] [?a :third ?x] :- [?x :foo ?y])]
+        ax [[:data :foo :bar]]
+        program (r/create-program rx ax)
+        [store results] (e/run {:type :memory} program)
+        data' (store/resolve-pattern store '[?e ?a ?v])
+        data (remove #(= [:data :foo :bar] %) data')
+        nodes (set (map first data))]
+    (is (= 6 (count data)))
+    (is (= 2 (count nodes)))
+    (is (some (fn [[e a v]] (and (nodes e) (= [:first :a] [a v]))) data))
+    (is (some (fn [[e a v]] (and (nodes e) (= [:first :b] [a v]))) data))
+    (is (some (fn [[e a v]] (and (nodes e) (= [:second :bar] [a v]))) data))
+    (is (some (fn [[e a v]] (and (nodes e) (= [:third :data] [a v]))) data))
+    (is (= 2 (count
+              (filter (fn [[e a v]]
+                        (and (= e v) (nodes e) (= :db/ident a)))
+                      data))))))
+
+;; todo blank-multi-prop
 
 (defn short-rule
   [{:keys [head body]}]
-  (concat [head :-] body))
+  (concat head [:-] body))
 
 (defn demo-family
   []


### PR DESCRIPTION
Fixes issue #54
Fixes issue #49
Fixes issue #48

Rules can now take multiple predicates in the head, setting multiple properties at once. These predicates can also contain unbound variables which can be used to instantiate new entities, and reference that same entity multiple times in the same production. Multiple new entities per production are also possible.