### PR TITLE
Decoupled state from input of programs.

### DIFF
--- a/src/naga/schema/structs.clj
+++ b/src/naga/schema/structs.clj
@@ -68,8 +68,15 @@
     [head :- Head
      body :- Body
      name :- s/Str
-     salience :- s/Num
      downstream :- [RulePatternPair]
+     salience :- s/Num])
+
+(s/defrecord DynamicRule
+    [head :- Head
+     body :- Body
+     name :- s/Str
+     downstream :- [RulePatternPair]
+     salience :- s/Num
      status :- {EPVPattern (s/atom ConstraintData)}
      execution-count :- (s/atom s/Num)])
 
@@ -88,12 +95,15 @@
     name :- s/Str
     downstream :- [RulePatternPair]
     salience :- s/Num]
-   (->Rule head body name salience downstream
-           (u/mapmap (fn [_]
-                       (atom {:last-count 0
-                              :dirty true}))
-                     (remove list? body))
-           (atom 0))))
+   (->Rule head body name downstream salience))
+  ([head :- Head
+    body :- Body
+    name :- s/Str
+    downstream :- [RulePatternPair]
+    salience :- s/Num
+    status :- {EPVPattern (s/atom ConstraintData)}
+    execution-count :- (s/atom s/Num)]
+   (->DynamicRule head body name downstream salience status execution-count)))
 
 (def EntityPropAxiomElt
   (s/cond-pre s/Keyword Long))
@@ -115,4 +125,8 @@
 
 (def Program
   {(s/required-key :rules) {s/Str Rule}
+   (s/required-key :axioms) [Axiom]})
+
+(def RunnableProgram
+  {(s/required-key :rules) {s/Str DynamicRule}
    (s/required-key :axioms) [Axiom]})

--- a/test/naga/test_rules.clj
+++ b/test/naga/test_rules.clj
@@ -49,12 +49,12 @@
   (let [ptn '[?a :ancestor ?b]
         r1 (new-rule '[[?a :parent ?b]] [ptn] "stub1" [])
         r2 (new-rule '[[?a :parent ?b]] [ptn] "stub2" [["stub2" ptn]])
-        p1 {:rules {"stub1" r1} :axioms []}
-        p2 {:rules {"stub2" r2} :axioms []}]
-    (e/execute (:rules p1) stest/empty-store)
-    (is (= 1 @(:execution-count r1)))
-    (e/execute (:rules p2) stest/empty-store)
-    (is (= 4 @(:execution-count r2)))))
+        p1 {:rules (e/initialize-rules {"stub1" r1}) :axioms []}
+        p2 {:rules (e/initialize-rules {"stub2" r2}) :axioms []}]
+    (let [[_ name->count] (e/execute (:rules p1) stest/empty-store)]
+      (is (= 1 (name->count "stub1"))))
+    (let [[_ name->count] (e/execute (:rules p2) stest/empty-store)]
+      (is (= 4 (name->count "stub2"))))))
 
 (deftest run-family
   (store/register-storage! :memory mem/create-store)


### PR DESCRIPTION
Initially the plan here was to remove all atoms. However, since rules can (and sometimes want to) run in parallel, then state per rule is the only effective way to do this.

Even without per-rule state, the way to keep rules in sync is to queue them by name, rather than by value. This makes salience promotion in the queue very difficult.

Between these reasons, and the need to monitor the rules at runtime, allowing rule state to be updated through a global rules object with the associated performance issues, keeping the per-rule state in atoms is the best approach.

Since rules only require this state at execution time, Rules no longer have this state, and instead a new type called the DynamicRule is constructed at the beginning of execution. This contains all the Rule data, and the dynamic state of the rule.