### PR TITLE
Handling independent entities in rules in Datomic

### DIFF
--- a/data/in.schema
+++ b/data/in.schema
@@ -2,3 +2,6 @@ id string
 sibling string
 parent string
 type string
+brother string
+uncle string
+rdf/type keyword

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.quoll/naga "0.2.1-SNAPSHOT"
+(defproject org.clojars.quoll/naga "0.2.1"
   :description "Forward Chaining Rule Engine"
   :url "http://github.com/threatgrid/naga"
   :license {:name "Eclipse Public License"

--- a/src/naga/storage/datomic/schema.clj
+++ b/src/naga/storage/datomic/schema.clj
@@ -59,7 +59,7 @@
   "Generates data for new attribute definitions, based on a file of attribute/type pairs."
   [file-text]
   (->> (s/split file-text #"\n")
-       (map #(s/split % #"\W+"))
+       (map #(s/split % #"\s+"))
        attribute-data))
 
 (defprotocol Dataschema

--- a/src/naga/storage/store_util.clj
+++ b/src/naga/storage/store_util.clj
@@ -78,7 +78,7 @@
    and if so checks if it already exists."
   [storage
    group :- [Axiom]]
-  (let [[entity _ val] (some (fn [[_ a _ :as axiom]] (when (= a :db/ident) axiom)) group)]
+  (if-let [[entity _ val :as g] (some (fn [[_ a _ :as axiom]] (when (= a :db/ident) axiom)) group)]
     (seq (store/resolve-pattern storage ['?e :db/ident val]))))
 
 (s/defn adorn-entities :- [Axiom]


### PR DESCRIPTION
Schemas with namespaced properties are now read correctly.
Checking for existing statements during insertion now works correctly.
Unbound patterns when querying datomic are now handled correctly.