### PR TITLE
Added delta support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.quoll/naga "0.2.3-SNAPSHOT"
+(defproject org.clojars.quoll/naga "0.2.3"
   :description "Forward Chaining Rule Engine"
   :url "http://github.com/threatgrid/naga"
   :license {:name "Eclipse Public License"
@@ -11,7 +11,7 @@
                  [the/parsatron "0.0.7"]
                  [cheshire "5.8.0"]
                  [org.clojars.quoll/naga-store "0.1.0"]
-                 [org.clojars.quoll/asami "0.2.0"]
+                 [org.clojars.quoll/asami "0.2.1"]
                  ; [com.datomic/datomic-pro "0.9.5697" :exclusions [com.google.guava/guava] ; uncomment for Datomic Pro
                  [com.datomic/datomic-free "0.9.5697" :exclusions [com.google.guava/guava]]
                  [org.postgresql/postgresql "9.3-1102-jdbc41"]]

--- a/src/naga/engine.cljc
+++ b/src/naga/engine.cljc
@@ -157,7 +157,7 @@
 
 (s/defn run :- [(s/one StorageType "Resulting data store")
                 (s/one {s/Str s/Num} "Execution stats")
-                (s/one (s/maybe {s/Str s/Num}) "Execution stats")]
+                (s/one (s/maybe [s/Any]) "Delta IDs")]
   "Runs a program against a given configuration"
   [config :- {s/Keyword s/Any}
    {:keys [rules axioms]} :- Program]

--- a/src/naga/storage/datomic/core.clj
+++ b/src/naga/storage/datomic/core.clj
@@ -171,12 +171,12 @@
 (defn top-ids
   "Adds to an accumulator all Database entities that represent a top level entity"
   [db ids acc]
-  (let [eids (q '[:find ?i
+  (let [eids (q '[:find [?i ...]
                   :in $ [?i ...]
                   :where [?i :naga/entity]] db ids)
         eids? (into #{} eids) 
         parented-ids (remove eids? ids)
-        pids (q '[:find ?pid
+        pids (q '[:find [?pid ...]
                   :in $ [?i ...]
                   :where [?pid ?a ?i]] db parented-ids)
         pids' (remove (into #{} parented-ids) pids)] ;; remove potential loops


### PR DESCRIPTION
Entity IDs of deltas are now returned by both Datomic and Asami. The `naga.data` namespace now includes the `delta->json` and `delta->str` functions. These have the same API as `store->json` and `store->str` functions, but return deltas only, instead of the entire graph.

Closes #86 