### PR TITLE
minor - prevents cljs compilation warning message

### DIFF
--- a/src/naga/queue.cljc
+++ b/src/naga/queue.cljc
@@ -30,6 +30,8 @@ of less salient elements."
             (cons e
                   (drop (count preamble) s)))))
 
+(declare ->SalienceQueue)
+
 (defrecord SalienceQueue
   [q ;; :- [s/Any]
    h ;; :- #{s/Any}


### PR DESCRIPTION
Prevents these warning lines during ClojureScript compilation:

```
WARNING: Use of undeclared Var naga.queue/->SalienceQueue at line 42 out/prod/naga/queue.cljc
WARNING: Use of undeclared Var naga.queue/->SalienceQueue at line 51 out/prod/naga/queue.cljc
WARNING: Use of undeclared Var naga.queue/->SalienceQueue at line 52 out/prod/naga/queue.cljc
```