### PR TITLE
Tidy up deps further by splitting out an uberjar profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
           :plugins [[lein-kibit "0.1.5"]]}
     :uberjar {
               :dependencies [[cheshire "5.10.0"]
-                             [org.clojure/tools.cli "0.3.5"]
+                             [org.clojure/tools.cli "1.0.194"]
                              [org.postgresql/postgresql "9.3-1102-jdbc41"]
                              [com.datomic/datomic-free "0.9.5697"]]
               :main naga.cli

--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.2"]
                  [prismatic/schema "1.1.12"]
-                 [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/core.cache "1.0.207"]
                  [org.clojars.quoll/parsatron "0.0.10"]
-                 [cheshire "5.10.0"]
                  [org.clojars.quoll/naga-store "0.5.2"]
                  [org.clojars.quoll/asami "1.2.14"]]
   :plugins [[lein-cljsbuild "1.1.8"]]
@@ -19,7 +17,15 @@
                      ; [com.datomic/datomic-pro "0.9.5697" :exclusions [com.google.guava/guava] ; uncomment for Datomic Pro
                      [com.datomic/datomic-free "0.9.5697" :exclusions [com.google.guava/guava]]
                      [org.postgresql/postgresql "9.3-1102-jdbc41"]]
-      :plugins [[lein-kibit "0.1.5"]]}}
+          :plugins [[lein-kibit "0.1.5"]]}
+    :uberjar {
+              :dependencies [[cheshire "5.10.0"]
+                             [org.clojure/tools.cli "0.3.5"]
+                             [org.postgresql/postgresql "9.3-1102-jdbc41"]
+                             [com.datomic/datomic-free "0.9.5697"]]
+              :main naga.cli
+              :aot [naga.cli]
+    }}
   :cljsbuild {
     :builds {
         :dev {
@@ -36,4 +42,7 @@
             :pretty-print true}}}
     :test-commands {
       "unit" ["node" "target/js/test.js"]}}
+
+  :target-path "target/%s/"
+
   :main ^:skip-aot naga.cli)

--- a/src/naga/cli.clj
+++ b/src/naga/cli.clj
@@ -16,7 +16,8 @@
             [naga.storage.asami.core])
   (:import [clojure.lang ExceptionInfo]
            [java.net URI]
-           [java.io File]))
+           [java.io File])
+  (:gen-class))
 
 (def stores (set (map name (keys @store-registry/registered-stores))))
 


### PR DESCRIPTION
Naga is both an app and a library, so move app deps into uberjar & dev profiles.

Also:

1. enable AOT in uberjar (not sure you need to disable this now for uberjar CLI users)
2. prevent profiles from contaminating classpath with `:target-path` (should mitigate against needing to `^:skip-aot`)
3. dropped exclusion on google.guava in uberjar profile (as it appears to be required for the uberjar now)

You could possibly go further by moving `naga.cli` into a separate source path that is only included in the uberjar profile (as library users probably don't require this namespace).  I didn't do this though as it then opens up more complex questions about where the datomic/asami storage backends should live e.g. separate deps etc, however ultimately I expect you don't want to introduce more dependencies at this stage.

Unfortunately because of the transitive dependency on zuko through asami you still seem to be bringing in cheshire transitivly, which then brings in the dreaded jackson.  If we know library users won't call a path that depends on this we could add an `:exclusion` for it.

Anyway just a speculative PR as you'd spent some time tidying the deps, I thought I'd see if we could improve it further.  I'm not 100% sure of your workflows etc though so it's possible this isn't an improvement or worth it.

Thanks again!